### PR TITLE
Port to pyproject.toml and resolve numpy installation issues

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,6 @@
 ACOR
 ====
+This is an updated, maintained fork of the `original acor <https://pypi.org/project/acor/>`_ package. Below is the original README with the appropriate changes to the name and source locations.
 
 This is a direct port of a C++ routine by
 `Jonathan Goodman <http://www.math.nyu.edu/faculty/goodman/index.html>`_ (NYU)
@@ -15,7 +16,7 @@ Installation
 
 Just run ::
 
-    pip install acor
+    pip install encor
 
 with ``sudo`` if you really need it.
 
@@ -23,12 +24,12 @@ Otherwise, download the source code
 `as a tarball <https://github.com/dfm/acor/tarball/master>`_
 or clone the git repository from `GitHub <https://github.com/dfm/acor>`_: ::
 
-    git clone https://github.com/dfm/acor.git
+    git clone https://github.com/davecwright3/acor.git
 
 Then run ::
 
     cd acor
-    python setup.py install
+    python -m pip install .
 
 to compile and install the module ``acor`` in your Python path. The only
 dependency is `NumPy <http://numpy.scipy.org/>`_ (including the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "acor"
-version = "1.1.1"
+version = "1.1.2"
 authors = [{name="Daniel Foreman-Mackey", email="danfm@nyu.edu"}, {name="Jonathan Goodman"}]
 description="Estimate the autocorrelation time of a time series quickly."
 classifiers=[

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["setuptools","numpy","wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "acor"
+version = "1.1.1"
+authors = [{name="Daniel Foreman-Mackey", email="danfm@nyu.edu"}, {name="Jonathan Goodman"}]
+description="Estimate the autocorrelation time of a time series quickly."
+classifiers=[
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python"
+    ]
+dependencies = ["numpy"]
+
+[project.urls]
+Homepage = "http://github.com/dfm/acor"
+
+[tool.setuptools]
+packages = ["acor"]
+license-files = ['LICEN[CS]E*']
+
+[tool.setuptools.dynamic]
+readme = {file = ["README.rst"]}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,10 @@ requires = ["setuptools","numpy","wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "acor"
-version = "1.1.2"
-authors = [{name="Daniel Foreman-Mackey", email="danfm@nyu.edu"}, {name="Jonathan Goodman"}]
+name = "encor"
+version = "1.1.4"
+authors = [{name="Daniel Foreman-Mackey and Jonathan Goodman", email="danfm@nyu.edu"},]
+maintainers = [{name="David Wright", email="david.wright@nanograv.org"}]
 description="Estimate the autocorrelation time of a time series quickly."
 classifiers=[
     "Development Status :: 3 - Alpha",
@@ -15,9 +16,9 @@ classifiers=[
     "Programming Language :: Python"
     ]
 dependencies = ["numpy"]
-
+dynamic = ["readme"]
 [project.urls]
-Homepage = "http://github.com/dfm/acor"
+Homepage = "http://github.com/davecwright3/acor"
 
 [tool.setuptools]
 packages = ["acor"]

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,6 @@ if sys.argv[-1] == "publish":
     sys.exit()
 
 
-desc = open("README.rst").read()
-required = ["numpy"]
-
 include_dirs = [
     "acor",
     numpy.get_include(),
@@ -31,22 +28,5 @@ acor = Extension("acor._acor", ["acor/_acor.c", "acor/acor.c"],
 
 
 setup(
-    name="acor",
-    version="1.1.1",
-    author="Daniel Foreman-Mackey and Jonathan Goodman",
-    author_email="danfm@nyu.edu",
-    packages=["acor"],
-    url="http://github.com/dfm/acor",
-    license="MIT",
-    description="Estimate the autocorrelation time of a time series quickly.",
-    long_description=desc,
-    install_requires=required,
     ext_modules=[acor],
-    classifiers=[
-        "Development Status :: 3 - Alpha",
-        "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python",
-    ],
 )


### PR DESCRIPTION
Ports relevant sections of `setup.py` to `pyproject.toml`.

Resolves #7 by specifying build dependencies (numpy) in `pyproject.toml`

Bump version 1.1.1 -> 1.1.2